### PR TITLE
Handle duplicated signup → guide to Login & Reset flow

### DIFF
--- a/src/pages/StartScreen.tsx
+++ b/src/pages/StartScreen.tsx
@@ -1,65 +1,31 @@
 import React from "react";
-import "./StartScreen.css";
 import { useNavigate } from "react-router-dom";
-import { useSettings } from "../settings/SettingsContext";
-import { ensureMicPermission } from "../utils/mic";
+import "./startscreen.css";
 
 export default function StartScreen() {
   const navigate = useNavigate();
-  const { locale, setLocale } = useSettings();
-
-  // 시작 버튼 클릭 시 실행
-  const handleStart = async () => {
-    const ok = await ensureMicPermission();
-    if (!ok) {
-      alert("마이크 권한이 필요합니다. 브라우저 설정에서 허용해주세요.");
-      return;
-    }
-    navigate("/voice-signup"); // 음성 회원가입 페이지로 이동
-  };
 
   return (
-    <div className="ys-root">
-      <div className="ys-container">
-        {/* 로고 */}
-        <div className="ys-logo" aria-label="Logo">Logo</div>
+    <div className="start-root">
+      <div className="start-card">
+        <div className="start-logo">Logo</div>
 
-        <h1 className="ys-title">YAGO SPORTS</h1>
-        <p className="ys-subtitle">AI Platform for Sports Enthusiasts</p>
+        <h1 className="start-title">YAGO SPORTS</h1>
+        <p className="start-subtitle">AI Platform for Sports Enthusiasts</p>
 
-        <div className="ys-desc">
-          <p>스포츠의 시작, 야고</p>
-          <p>체육인 커뮤니티, 장터, 모임까지</p>
-          <p>지금 위치를 선택하고 시작해보세요!</p>
-        </div>
-
-        {/* 언어/지역 선택 */}
-        <div className="ys-select-wrap">
-          <span className="ys-select-icon" aria-hidden>
-            <svg viewBox="0 0 24 24" width="18" height="18">
-              <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm7.93 9H17.5a15.7 15.7 0 0 0-1.23-5A8.03 8.03 0 0 1 19.93 11ZM15.9 11H8.1a14.3 14.3 0 0 1 1.3-4.9c.56-1.1 1.16-1.9 2.6-1.9s2.04.8 2.6 1.9c.53 1.03.97 2.22 1.3 3.9ZM6.73 6A15.7 15.7 0 0 0 5.5 11H4.07A8.03 8.03 0 0 1 6.73 6ZM4.07 13H5.5c.24 1.76.77 3.52 1.23 5A8.03 8.03 0 0 1 4.07 13Zm3.03 0h9.8a14.3 14.3 0 0 1-1.3 4.9c-.56 1.1-1.16 1.9-2.6 1.9s-2.04-.8-2.6-1.9A14.3 14.3 0 0 1 7.1 13Zm8.17 5c.46-1.48.99-3.24 1.23-5h2.43a8.03 8.03 0 0 1-2.66 5Z"/>
-            </svg>
-          </span>
-          <select
-            className="ys-select"
-            value={locale}
-            onChange={(e) => setLocale(e.target.value)}
-            aria-label="언어 선택"
-          >
-            <option value="ko-KR">한국어 (대한민국)</option>
-            <option value="en-US">English (US)</option>
-            <option value="ja-JP">日本語</option>
-            <option value="zh-CN">简体中文</option>
-          </select>
-          <span className="ys-caret" aria-hidden>▼</span>
-        </div>
-
-        {/* 시작 버튼 */}
-        <button className="ys-button" onClick={handleStart}>시작하기</button>
-
-        <p className="ys-login">
-          이미 계정이 있나요? <a href="/login">로그인</a>
+        <p className="start-desc">
+          스코어와 기록, AI로 채워지는 커뮤니티. 정답, 요약까지! 지금 원하는 팀/리그로
+          시작해보세요.
         </p>
+
+        <button className="start-btn" onClick={() => navigate("/signup")}>
+          시작하기
+        </button>
+
+        <div className="start-login">
+          이미 계정이 있나요?
+          <a href="/login" className="start-login-link">로그인</a>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/startscreen.css
+++ b/src/pages/startscreen.css
@@ -1,122 +1,83 @@
-/* 페이지 전체 */
-.ys-root {
+/* 화면 전체 중앙정렬 */
+.start-root {
   min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #ffffff;
-  color: #2b3748;
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  display: grid;
+  place-items: center;
+  background: #f7f8fb;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Noto Sans KR",
+    Helvetica, Arial, "Apple SD Gothic Neo", "Malgun Gothic", "맑은 고딕", sans-serif;
+  color: #111827;
 }
 
-/* 중앙 컨테이너 */
-.ys-container {
-  width: 92%;
-  max-width: 420px;
-  text-align: center;
-  margin: 40px auto;
-}
-
-/* 로고 */
-.ys-logo {
-  width: 76px;
-  height: 30px;
-  margin: 0 auto 18px;
-  color: #7a8aa0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-/* 타이틀/서브타이틀 */
-.ys-title {
-  font-size: 34px;
-  letter-spacing: 1px;
-  font-weight: 800;
-  margin: 0 0 8px;
-}
-.ys-subtitle {
-  margin: 0 0 24px;
-  color: #7a8aa0;
-}
-
-/* 설명 문단 */
-.ys-desc {
-  line-height: 1.7;
-  color: #445166;
-  margin-bottom: 18px;
-}
-
-/* 선택 박스(언어/지역) */
-.ys-select-wrap {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin: 8px 0 24px;
-  padding: 0;
-}
-.ys-select-icon {
-  position: absolute;
-  left: 12px;
-}
-.ys-select {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  padding: 10px 42px 10px 40px; /* 왼쪽 아이콘, 오른쪽 캐럿 공간 */
-  border: 2px solid #e2e8f0;
-  border-radius: 10px;
+/* 카드 */
+.start-card {
+  width: 360px;
   background: #fff;
-  font-size: 15px;
-  color: #2b3748;
-  outline: none;
-  transition: box-shadow .15s ease, border-color .15s ease;
-}
-.ys-select:focus {
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59,130,246,.2);
-}
-.ys-caret {
-  position: absolute;
-  right: 14px;
-  font-size: 10px;
-  color: #334155;
-  pointer-events: none;
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+  padding: 28px 24px;
+  text-align: center;
 }
 
-/* 시작 버튼 */
-.ys-button {
+/* 로고 자리 */
+.start-logo {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 14px;
+  border-radius: 12px;
+  background: #eef2ff;
+  color: #3b82f6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+
+/* 타이틀/텍스트 */
+.start-title {
+  margin: 4px 0 2px;
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: 0.2px;
+}
+
+.start-subtitle {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.start-desc {
+  font-size: 13px;
+  color: #374151;
+  line-height: 1.5;
+  margin: 0 0 18px;
+}
+
+/* 버튼/링크 */
+.start-btn {
   width: 100%;
-  max-width: 320px;
-  margin: 4px auto 16px;
-  border: 0;
+  padding: 12px 14px;
+  border: none;
   border-radius: 10px;
-  background: #2563eb;     /* 파란색 */
+  background: #2563eb;
   color: #fff;
-  padding: 12px 18px;
-  font-size: 18px;
   font-weight: 700;
   cursor: pointer;
-  box-shadow: 0 4px 14px rgba(37,99,235,.22);
-  transition: transform .05s ease, filter .15s ease, background .15s ease;
+  transition: transform 0.04s ease, filter 0.2s ease;
 }
-.ys-button:hover { filter: brightness(1.03); }
-.ys-button:active { transform: translateY(1px); }
+.start-btn:hover { filter: brightness(1.05); }
+.start-btn:active { transform: translateY(1px); }
 
-/* 로그인 링크 */
-.ys-login {
-  color: #7a8aa0;
-  margin-top: 10px;
+.start-login {
+  margin-top: 12px;
+  font-size: 13px;
+  color: #6b7280;
 }
-.ys-login a {
+.start-login-link {
+  margin-left: 6px;
   color: #2563eb;
   text-decoration: none;
 }
-.ys-login a:hover { text-decoration: underline; }
-
-/* 반응형(좁은 화면 간격 조정) */
-@media (max-width: 360px) {
-  .ys-title { font-size: 30px; }
-  .ys-container { margin: 24px auto; }
-}
+.start-login-link:hover { text-decoration: underline; }


### PR DESCRIPTION
### Changes
- Handle `auth/email-already-in-use`: 안내 + **[로그인하기] / [비밀번호 재설정]** CTA
- Add **/login** page (email prefill) and routing (/ , /signup, /login)
- UI: Start screen **card** 적용 (시작하기 버튼 + 로그인 링크)
- Remove duplicate Firebase initialization (use shared `auth`/`db` from `src/firebase/firebase.ts`)
- Stabilize voice parsers (name/email/password): spelling mode, domain correction, dot preservation

### Test Scenarios
1. New email signup → 성공
2. Same email re-signup → “이미 가입된 이메일입니다.” + CTA 노출  
   - [로그인하기] → `/login?email=...` (prefill)  
   - [비밀번호 재설정] → reset 메일 발송 안내
3. `/` → 스타트 카드 노출, **시작하기** → `/signup`, **로그인** → `/login`

### Checklist
- [ ] Firebase 초기화는 `src/firebase/firebase.ts` 한 곳만 사용하는지
- [ ] `/login` / `/signup` / `/` 라우팅 정상
- [ ] 음성 입력 파싱(ID/도메인) 동작 확인
- [ ] 빌드 및 Lint 오류 없음
